### PR TITLE
Add bitcopy0

### DIFF
--- a/mbed-client-libservice/common_functions.h
+++ b/mbed-client-libservice/common_functions.h
@@ -260,7 +260,11 @@ bool bitsequal(const uint8_t *a, const uint8_t *b, uint_fast8_t bits);
  * Copy a bitstring
  *
  * Copy a bitstring of specified length. The bit string is in big-endian
- * (network) bit order.
+ * (network) bit order. Bits beyond the bitlength at the destination are not
+ * modified.
+ *
+ * For example, copying 4 bits sets the first 4 bits of dst[0] from src[0],
+ * the lower 4 bits of dst[0] are unmodified.
  *
  * \param dst destination pointer
  * \param src source pointer
@@ -269,6 +273,24 @@ bool bitsequal(const uint8_t *a, const uint8_t *b, uint_fast8_t bits);
  * \return the value of dst
  */
 uint8_t *bitcopy(uint8_t *restrict dst, const uint8_t *restrict src, uint_fast8_t bits);
+
+/*
+ * Copy a bitstring and pad last byte with zeros
+ *
+ * Copy a bitstring of specified length. The bit string is in big-endian
+ * (network) bit order. Bits beyond the bitlength in the last destination byte are
+ * zeroed.
+ *
+ * For example, copying 4 bits sets the first 4 bits of dst[0] from src[0], and
+ * the lower 4 bits of dst[0] are set to 0.
+ *
+ * \param dst destination pointer
+ * \param src source pointer
+ * \param bits number of bits to copy
+ *
+ * \return the value of dst
+ */
+uint8_t *bitcopy0(uint8_t *restrict dst, const uint8_t *restrict src, uint_fast8_t bits);
 
 /* Provide definitions, either for inlining, or for common_functions.c */
 #if defined NS_ALLOW_INLINING || defined COMMON_FUNCTIONS_FN

--- a/source/libBits/common_functions.c
+++ b/source/libBits/common_functions.c
@@ -66,3 +66,21 @@ uint8_t *bitcopy(uint8_t *restrict dst, const uint8_t *restrict src, uint_fast8_
 
     return dst;
 }
+
+uint8_t *bitcopy0(uint8_t *restrict dst, const uint8_t *restrict src, uint_fast8_t bits)
+{
+    uint_fast8_t bytes = bits / 8;
+    bits %= 8;
+
+    if (bytes) {
+        dst = (uint8_t *) memcpy(dst, src, bytes) + bytes;
+        src += bytes;
+    }
+
+    if (bits) {
+        uint_fast8_t split_bit = context_split_mask(bits);
+        *dst = (*src & split_bit);
+    }
+
+    return dst;
+}


### PR DESCRIPTION
Add a variant of bitcopy that zero-fills spare bits in the destination
byte, rather than preserving them.