### PR TITLE
ns_trace: check before using the value of m_trace.line

### DIFF
--- a/source/libTrace/ns_trace.c
+++ b/source/libTrace/ns_trace.c
@@ -234,6 +234,13 @@ static void default_print(const char *str)
 }
 void tracef(uint8_t dlevel, const char *grp, const char *fmt, ...)
 {
+    if (m_trace.line == NULL) {
+        // Quite likely the trace_init() has not been called yet,
+        // but it is better to just shut up instead of crashing with
+        // null pointer dereference. 
+        return;
+    }
+    
     m_trace.line[0] = 0; //by default trace is empty
     if (trace_skip(dlevel, grp) || fmt == 0 || grp == 0) {
         return;


### PR DESCRIPTION
If the board initialization has not yet called the trace_init()
before it issued a tracef() call, the code dereferenced a null
pointer. Verify the value of m_trace.line before using it to
avoid the crash. It is easier to debug a missing tracef() than
a board crash during the initialization.

@jupe @SeppoTakalo 