### PR TITLE
Use malloc/free in mbedOS debug build tracing (ONME-2285)

### DIFF
--- a/mbed-client-libservice/ns_trace.h
+++ b/mbed-client-libservice/ns_trace.h
@@ -101,12 +101,12 @@ extern "C" {
 
 #if defined  __GNUC__ || defined __CC_ARM
 /**
- * Initialize trace functionality
+ * Initialize trace functionality. This method must be called from application process.
  * @return 0 when all success, otherwise non zero
  */
 int trace_init( void );
 /**
- * Free trace memory
+ * Free trace memory. This method must be called from application process.
  */
 void trace_free( void );
 /**

--- a/source/libTrace/ns_trace.c
+++ b/source/libTrace/ns_trace.c
@@ -24,7 +24,8 @@
 #include "ip6string.h"
 #include "common_functions.h"
 
-#if defined(_WIN32) || defined(__unix__) || defined(__unix) || defined(unix)
+#if defined(_WIN32) || defined(__unix__) || defined(__unix) || defined(unix) || (defined(YOTTA_CFG) && !defined(NDEBUG))
+//NOTE! It is not allowed to use this MEM_ALLOC/MEM_FREE from interrupt context.
 #ifndef MEM_ALLOC
 #define MEM_ALLOC malloc
 #endif


### PR DESCRIPTION
Use malloc/free instead of ns_dyn_mem_alloc/free when tracing mbed
debug builds. nsdynmemlib is using platform_enter_critical() and
platform_exit_critical() that are not always available in mbed builds.

@SeppoTakalo , @anttiylitokola would you please review?